### PR TITLE
Add interactive SHAP and DAG visual grouping

### DIFF
--- a/src/components/visualizations/DAGVisual.tsx
+++ b/src/components/visualizations/DAGVisual.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { DAGData } from '../../types';
 import { VisualCard } from './VisualCard';
-import { GitBranch, ArrowRight } from 'lucide-react';
+import { GitBranch } from 'lucide-react';
+
+const groupColors = [
+  'border-blue-500',
+  'border-green-500',
+  'border-yellow-500',
+  'border-purple-500'
+];
 
 interface DAGVisualProps {
   dagData?: DAGData;
@@ -9,6 +16,10 @@ interface DAGVisualProps {
 
 export const DAGVisual: React.FC<DAGVisualProps> = ({ dagData }) => {
   if (!dagData || !dagData.nodes || !dagData.edges) return null;
+
+  const groups = Array.from(new Set(dagData.nodes.map(n => n.group).filter(Boolean))) as string[];
+  const colorMap: Record<string, string> = {};
+  groups.forEach((g, i) => { colorMap[g] = groupColors[i % groupColors.length]; });
 
   const nodePositions = dagData.nodes.reduce((acc, node, i) => ({
     ...acc,
@@ -29,7 +40,7 @@ export const DAGVisual: React.FC<DAGVisualProps> = ({ dagData }) => {
       
       <div className="relative h-64 bg-slate-900/30 rounded-lg p-4 overflow-hidden">
         {/* Nodes */}
-        {dagData.nodes.map((node, index) => (
+        {dagData.nodes.map((node) => (
           <div
             key={node.id}
             className="absolute transform -translate-x-1/2 -translate-y-1/2 group"
@@ -38,11 +49,20 @@ export const DAGVisual: React.FC<DAGVisualProps> = ({ dagData }) => {
               top: nodePositions[node.id].y
             }}
           >
-            <div className="bg-slate-700 border-2 border-blue-500/50 px-4 py-3 rounded-lg text-center text-sm font-medium text-white shadow-lg group-hover:border-blue-400 group-hover:shadow-blue-500/25 transition-all duration-300">
+            <div
+              className={`relative bg-slate-700 border-2 px-4 py-3 rounded-lg text-center text-sm font-medium text-white shadow-lg transition-all duration-300 ${node.group ? colorMap[node.group] : 'border-blue-500'} group-hover:shadow-blue-500/25`}
+            >
               <div className="flex items-center justify-center">
                 <GitBranch className="w-4 h-4 mr-2 text-blue-400" />
                 {node.label}
               </div>
+              {(node.description || node.importance) && (
+                <div className="absolute left-full top-1/2 ml-3 w-56 -translate-y-1/2 rounded-lg bg-slate-800 p-3 text-xs text-gray-300 shadow-lg opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto transition-opacity">
+                  {node.description && <p className="font-semibold text-white mb-1">{node.description}</p>}
+                  {node.importance && <p className="mb-1">{node.importance}</p>}
+                  {node.whatIf && <p className="italic text-gray-400">What if: {node.whatIf}</p>}
+                </div>
+              )}
             </div>
           </div>
         ))}
@@ -86,6 +106,17 @@ export const DAGVisual: React.FC<DAGVisualProps> = ({ dagData }) => {
               );
             })}
         </svg>
+
+        {groups.length > 0 && (
+          <div className="absolute bottom-2 left-2 flex flex-wrap gap-4 text-xs">
+            {groups.map(g => (
+              <div key={g} className="flex items-center text-gray-300">
+                <span className={`w-3 h-3 mr-2 rounded-full ${colorMap[g]}`}></span>
+                {g}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </VisualCard>
   );

--- a/src/components/visualizations/SHAPVisual.tsx
+++ b/src/components/visualizations/SHAPVisual.tsx
@@ -2,6 +2,47 @@ import React from 'react';
 import { VisualCard } from './VisualCard';
 import { TrendingUp, TrendingDown } from 'lucide-react';
 
+interface FeatureInfo {
+  group: string;
+  description: string;
+  why: string;
+  value?: string;
+}
+
+// Mapping of features to group and descriptions used for tooltips
+const featureInfoMap: Record<string, FeatureInfo> = {
+  'Flight Deviation': {
+    group: 'Flight Data',
+    description: 'How far the aircraft deviated from its planned route.',
+    why: 'High flight deviation is often seen in evasive manoeuvres.',
+    value: 'Large course change'
+  },
+  'Speed Increase': {
+    group: 'Flight Data',
+    description: 'Change in air speed relative to plan.',
+    why: 'Rapid acceleration can signal intentional course change.',
+    value: 'Significant increase'
+  },
+  'ATC Non-Response': {
+    group: 'Communications',
+    description: 'Lack of reply to Air Traffic Control calls.',
+    why: 'Communication silence indicates possible hostile intent.',
+    value: 'No reply'
+  },
+  'Geographic Vector': {
+    group: 'Route',
+    description: 'Current approach relative to critical infrastructure.',
+    why: 'Approach vector may indicate an attack posture.',
+    value: 'Aligned with targets'
+  },
+  'Time of Day': {
+    group: 'Environmental',
+    description: 'Operational context based on day or night.',
+    why: 'Certain times correlate with higher threat activity.',
+    value: 'Night hours'
+  }
+};
+
 interface SHAPVisualProps {
   shapData?: Record<string, number>;
 }
@@ -12,46 +53,64 @@ export const SHAPVisual: React.FC<SHAPVisualProps> = ({ shapData }) => {
   const features = Object.entries(shapData).sort(([, a], [, b]) => Math.abs(b) - Math.abs(a));
   const maxAbsValue = Math.max(...features.map(([, v]) => Math.abs(v)));
 
+  // Group features by their source/type
+  const grouped = features.reduce<Record<string, Array<[string, number]>>>(
+    (acc, [feature, val]) => {
+      const info = featureInfoMap[feature];
+      const group = info ? info.group : 'Other';
+      if (!acc[group]) acc[group] = [];
+      acc[group].push([feature, val]);
+      return acc;
+    },
+    {}
+  );
+
   return (
     <VisualCard>
       <div className="flex items-center mb-6">
         <TrendingUp className="w-6 h-6 text-teal-400 mr-3" />
-        <h3 className="text-lg font-semibold text-teal-300">
-          SHAP Feature Importance
-        </h3>
+        <h3 className="text-lg font-semibold text-teal-300">SHAP Feature Importance</h3>
       </div>
-      
-      <div className="space-y-4">
-        {features.map(([feature, value]) => (
-          <div key={feature} className="group">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium text-gray-300 group-hover:text-white transition-colors">
-                {feature}
-              </span>
-              <div className="flex items-center">
-                {value > 0 ? (
-                  <TrendingUp className="w-4 h-4 text-green-400 mr-1" />
-                ) : (
-                  <TrendingDown className="w-4 h-4 text-red-400 mr-1" />
-                )}
-                <span className={`text-sm font-bold ${value > 0 ? 'text-green-400' : 'text-red-400'}`}>
-                  {value.toFixed(2)}
-                </span>
-              </div>
-            </div>
-            
-            <div className="relative bg-slate-700/50 rounded-full h-3 overflow-hidden">
-              <div
-                style={{ width: `${(Math.abs(value) / maxAbsValue) * 100}%` }}
-                className={`
-                  h-full transition-all duration-500 ease-out
-                  ${value > 0 
-                    ? 'bg-gradient-to-r from-green-500 to-green-400' 
-                    : 'bg-gradient-to-r from-red-500 to-red-400'
-                  }
-                `}
-              />
-            </div>
+
+      <div className="space-y-6">
+        {Object.entries(grouped).map(([group, feats]) => (
+          <div key={group} className="space-y-4">
+            <h4 className="text-sm font-semibold text-gray-400">{group}</h4>
+            {feats.map(([feature, value]) => {
+              const info = featureInfoMap[feature];
+              return (
+                <div key={feature} className="group relative">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-sm font-medium text-gray-300 group-hover:text-white transition-colors">
+                      {feature}
+                    </span>
+                    <div className="flex items-center">
+                      {value > 0 ? (
+                        <TrendingUp className="w-4 h-4 text-green-400 mr-1" />
+                      ) : (
+                        <TrendingDown className="w-4 h-4 text-red-400 mr-1" />
+                      )}
+                      <span className={`text-sm font-bold ${value > 0 ? 'text-green-400' : 'text-red-400'}`}>{value.toFixed(2)}</span>
+                    </div>
+                  </div>
+
+                  <div className="relative bg-slate-700/50 rounded-full h-3 overflow-hidden">
+                    <div
+                      style={{ width: `${(Math.abs(value) / maxAbsValue) * 100}%` }}
+                      className={`h-full transition-all duration-500 ease-out ${value > 0 ? 'bg-gradient-to-r from-green-500 to-green-400' : 'bg-gradient-to-r from-red-500 to-red-400'}`}
+                    />
+                  </div>
+
+                  {info && (
+                    <div className="absolute left-full top-1/2 ml-3 w-56 -translate-y-1/2 rounded-lg bg-slate-800 p-3 text-xs text-gray-300 shadow-lg opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto transition-opacity">
+                      <p className="font-semibold text-white mb-1">{info.description}</p>
+                      <p className="mb-1">{info.why}</p>
+                      <p className="text-teal-300">Value: {info.value ?? value.toFixed(2)}</p>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
         ))}
       </div>

--- a/src/data/scenarios.ts
+++ b/src/data/scenarios.ts
@@ -44,11 +44,45 @@ export const xaiExplanation: XAIExplanation = {
     text: "Threat correlation analysis:\n• Flight pattern matches 85% of known adversarial profiles\n• Speed increase suggests intentional course change\n• Communication silence indicates potential hostile intent\n• Geographic approach vector is tactically significant",
     dag: {
       nodes: [
-        { id: 'deviation', label: 'Flight Deviation' },
-        { id: 'speed', label: 'Speed Increase' },
-        { id: 'communication', label: 'ATC Silence' },
-        { id: 'geography', label: 'Approach Vector' },
-        { id: 'threat', label: 'Threat Assessment' }
+        {
+          id: 'deviation',
+          label: 'Flight Deviation',
+          group: 'Flight Data',
+          description: 'Deviation from original flight path',
+          importance: 'Indicates potential evasive manoeuvre',
+          whatIf: 'Less deviation lowers threat'
+        },
+        {
+          id: 'speed',
+          label: 'Speed Increase',
+          group: 'Flight Data',
+          description: 'Increase in aircraft speed',
+          importance: 'Suggests intentional course change',
+          whatIf: 'Slowing down may indicate compliance'
+        },
+        {
+          id: 'communication',
+          label: 'ATC Silence',
+          group: 'Communications',
+          description: 'No response to ATC calls',
+          importance: 'Silence often precedes hostile intent',
+          whatIf: 'Responding would ease concern'
+        },
+        {
+          id: 'geography',
+          label: 'Approach Vector',
+          group: 'Route',
+          description: 'Vector toward critical infrastructure',
+          importance: 'May indicate attack posture',
+          whatIf: 'Different route reduces suspicion'
+        },
+        {
+          id: 'threat',
+          label: 'Threat Assessment',
+          group: 'Assessment',
+          description: 'Overall threat evaluation',
+          importance: 'Aggregates indicators to gauge risk'
+        }
       ],
       edges: [
         { from: 'deviation', to: 'threat' },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,9 +48,23 @@ export interface XAIExplanation {
   suggestedPrompts?: string[];
 }
 
+export interface DAGNode {
+  id: string;
+  label: string;
+  group?: string;
+  description?: string;
+  importance?: string;
+  whatIf?: string;
+}
+
+export interface DAGEdge {
+  from: string;
+  to: string;
+}
+
 export interface DAGData {
-  nodes: Array<{ id: string; label: string }>;
-  edges: Array<{ from: string; to: string }>;
+  nodes: DAGNode[];
+  edges: DAGEdge[];
 }
 
 export interface AlternativeOutcome {


### PR DESCRIPTION
## Summary
- enhance SHAP visual with feature grouping and tooltips
- color and group nodes in DAG graph with interactive explanations
- extend DAG types for extra node info
- update sample scenario data with node metadata

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c5cd05e38832887f7071b2283f0a7